### PR TITLE
Rename search tool refresh button id

### DIFF
--- a/js/searchToolFrontEnd.js
+++ b/js/searchToolFrontEnd.js
@@ -11,7 +11,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const detailsContent = document.getElementById('detailsContent');
     const copyBtn = document.getElementById('copyBtn');
     const closeBtn = document.getElementById('closeBtn');
-	const refresListhSearchToolBtn = document.getElementById('refresListhSearchToolBtn');
+	const refreshSearchToolBtn = document.getElementById('refreshSearchToolBtn');
 	
 	let useStreaming = true; // Set to false to use regular fetch
 
@@ -362,12 +362,12 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     });
 	
-	// 🌟 Refresh log list dropdown
-	document.getElementById("refresListhSearchToolBtn").addEventListener("click", () => {
-	  console.log("🔄 Search Tool Refresh List button clicked.");
-    // ✅ Populate the fileSelect dropdown on page load
-    populateFileSelect();
-	});
+        // 🌟 Refresh log list dropdown
+        refreshSearchToolBtn.addEventListener("click", () => {
+          console.log("🔄 Search Tool Refresh List button clicked.");
+          // ✅ Populate the fileSelect dropdown on demand
+          populateFileSelect();
+        });
 }); // END --- closing bracket for DOMContentLoaded function
 
 // ✅ NEW: Log search action to AI logger

--- a/templates/index.html
+++ b/templates/index.html
@@ -168,7 +168,7 @@
 					<select id="fileSelect" class="searchtoolfilters-select">
 					  <option value="">-- Select Target File --</option>
 					</select>
-					<button id="refresListhSearchToolBtn" class="searchtoolfilters-button" title="Refresh Log List">🔄 Refresh List</button>
+					<button id="refreshSearchToolBtn" class="searchtoolfilters-button" title="Refresh Log List">🔄 Refresh List</button>
 					<button id="searchBtn" class="searchtoolfilters-button" title="Search Keywords">🔍 Search</button>
 					<label class="searchtoolfilters-label">
 					  <input type="checkbox" id="streamingToggle" checked disabled hidden> <!-- Use Real-Time Streaming -->


### PR DESCRIPTION
## Summary
- Rename Search Tools refresh list button id to `refreshSearchToolBtn` in index template and JS
- Bind the refresh list event handler to the renamed button element

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895f8ec1f2c8323bddfd20bceb11f61