### PR TITLE
Rename duplicate error summary ID in index template

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -62,8 +62,8 @@
 					<em>🔬 No analysis yet. Please select a log and click analyze.</em>
 				</div>
 
-				 <div id="errorCountSummary" class="error-summary">
-					<div id="errorCountSummary" class="error-summary">
+                                 <div id="errorCountSummary" class="error-summary">
+                                        <div id="errorCountSummaryInner" class="error-summary">
 					  <h3>📄 Total Number of Errors Found</h3>
 
 					  <!-- 🧱 Flex Container for 3 Error Types -->


### PR DESCRIPTION
## Summary
- Rename nested error summary element to `errorCountSummaryInner`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68965ecc1fa483239a6aea9f37f59bdd